### PR TITLE
Fix typo in generator description

### DIFF
--- a/.atomist/editors/AddMidje.rug
+++ b/.atomist/editors/AddMidje.rug
@@ -3,7 +3,7 @@
 @tag "midje"
 @tag "testing"
 
-@description "Add Midje support to a Leingingen project"
+@description "Add Midje support to a Leiningen project"
 editor AddMidje
 
 with clojure.lein  


### PR DESCRIPTION
"Leiningen" is hard to spell.
This shows up in atomist-community slack when I type `@atomist generators` so it would be nice to fix it, please.